### PR TITLE
Added Prometheus exporter output mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ env
 venv
 .venv
 *.pyc
+__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,68 @@
-FROM python:3
+# ──────────────────────────────────────────────────────────────────────────────
+# essstat — TP-Link Easy Smart Switch port statistics
+# ──────────────────────────────────────────────────────────────────────────────
+#
+# Two modes of operation:
+#
+# 1. CLI mode (original behaviour) — run essstat.py with any args:
+#
+#      docker build -t essstat .
+#      docker run --rm essstat myswitch -p ChangeMe
+#      docker run --rm essstat myswitch -p ChangeMe -j
+#      docker run --rm essstat myswitch -p ChangeMe -P   # one-shot prometheus
+#
+# 2. Exporter mode — long-running HTTP server for Prometheus pull scraping:
+#
+#      docker run -d \
+#        -e EXPORTER=1 \
+#        -e ESS_HOST=myswitch \
+#        -e ESS_PASSWORD=secret \
+#        -p 9101:9101 \
+#        essstat
+#
+#   Then scrape http://localhost:9101/metrics from Prometheus.
+#
+#   Optional env vars for exporter mode:
+#     ESS_USERNAME  (default: admin)
+#     ESS_LISTEN    (default: 0.0.0.0:9101)
+#
+#   docker-compose example for multiple switches:
+#
+#     services:
+#       essstat-sw1:
+#         image: essstat
+#         environment:
+#           EXPORTER: "1"
+#           ESS_HOST: 192.168.1.10
+#           ESS_PASSWORD: secret1
+#         ports: ["9101:9101"]
+#       essstat-sw2:
+#         image: essstat
+#         environment:
+#           EXPORTER: "1"
+#           ESS_HOST: 192.168.1.11
+#           ESS_PASSWORD: secret2
+#           ESS_LISTEN: 0.0.0.0:9102
+#         ports: ["9102:9102"]
+# ──────────────────────────────────────────────────────────────────────────────
 
-WORKDIR /essstat
+FROM python:3-alpine
 
-COPY requirements.txt ./
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+# Copy application files
+COPY essstat.py           .
+COPY essstat_exporter.py  .
 
-ENTRYPOINT ["python", "essstat.py"]
+# Copy and register the entrypoint
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Expose the Prometheus metrics port (only used in exporter mode)
+EXPOSE 9101
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 They are managed through a web based interface, giving access a number of functions, including basic packets counters per-port. 
 Unfortunately, these switches do not implement SNMP for access to these counters, nor do they appear to implement a discrete URL for
 direct access to this information. This project addresses this issue to produce per-port statistics from a single command line invocation 
-with output that can be trivially parsed for formatted output, or entered into a monitoring system like Zabbix.
+with output that can be trivially parsed for formatted output, or entered into a monitoring system like Zabbix or Prometheus.
 
 This project has been tested against TP-Link switch models TL-SG1016DE, TL-SG108E and TL-SG108PE. It should also be compatible with the other 
 members of this family, including the TL-SG105E and TL-SG1024DE.
@@ -35,7 +35,7 @@ Python&nbsp;3.6 and uses the [Beautiful Soup](https://pypi.org/project/beautiful
 
 #### Usage
 
-    essstat.py [-h] [-1] [-d] [-j] [-l] -p TPpswd [-u TPuser] [-s] [--port PORT] [--metric METRIC] TPhost
+    essstat.py [-h] [-1] [-d] [-j] [-l] [-P] -p TPpswd [-u TPuser] [-s] [-n PORT] [-M METRIC] TPhost
     
 #### Options
 
@@ -51,16 +51,20 @@ Python&nbsp;3.6 and uses the [Beautiful Soup](https://pypi.org/project/beautiful
   -i, --info            fetch system info instead of port statistics
   -j, --json            output as JSON
   -l, --lld             output in Zabbix LLD JSON format
+  -P, --prometheus      output in Prometheus text exposition format (for /metrics scraping)
   -p TPpswd, --password TPpswd
                         password for switch access
   -u TPuser, --username TPuser
                         username for switch access
   -s, --statsonly       output per-port statistics only (one line per port)
-  -P PORT, --port PORT  specific port number to retrieve
+  -n PORT, --port PORT  specific port number to retrieve
   -M METRIC, --metric METRIC
                         metric name for specific port (state, link_status, TxGoodPkt, TxBadPkt, RxGoodPkt, RxBadPkt)
   -v, --Version         show program's version number and exit
 ```
+
+> **Note:** the short flag for `--port` was previously `-P`. It has been renamed to `-n` to free `-P` for `--prometheus`.
+> If you have scripts or Zabbix `UserParameter` entries using `-P <number>`, update them to `-n <number>`.
 
 #### Example
 
@@ -76,10 +80,85 @@ Python&nbsp;3.6 and uses the [Beautiful Soup](https://pypi.org/project/beautiful
     7;Enabled;1000M Full;2903398648,0,4293632425,5
     8;Enabled;Link Down;0,0,0,0
 
-#### Docker Example
+#### Docker
+
+The image supports two modes of operation controlled by environment variables.
+
+##### Build
 
     $ docker build -t essstat .
+
+##### CLI mode (default — original behaviour)
+
+Pass any `essstat.py` arguments directly after the image name, exactly as on the command line:
+
     $ docker run --rm essstat myswitch -p ChangeMe
+    $ docker run --rm essstat myswitch -p ChangeMe -j
+    $ docker run --rm essstat myswitch -p ChangeMe -P    # one-shot Prometheus dump to stdout
+
+##### Exporter mode — long-running Prometheus HTTP endpoint
+
+Set `EXPORTER=1` to start a persistent `/metrics` HTTP server instead of running a one-shot scrape.
+Credentials and connection details are passed via environment variables:
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `EXPORTER` | yes | — | Set to `1` to enable exporter mode |
+| `ESS_HOST` | yes | — | Switch IP address or hostname |
+| `ESS_PASSWORD` | yes | — | Switch admin password |
+| `ESS_USERNAME` | no | `admin` | Switch admin username |
+| `ESS_LISTEN` | no | `0.0.0.0:9101` | Address and port to listen on |
+
+    $ docker run -d \
+        -e EXPORTER=1 \
+        -e ESS_HOST=myswitch \
+        -e ESS_PASSWORD=secret \
+        -p 9101:9101 \
+        essstat
+
+Prometheus then scrapes `http://host:9101/metrics`. Add to `prometheus.yml`:
+
+    scrape_configs:
+      - job_name: tplink_switch
+        static_configs:
+          - targets: ['localhost:9101']
+
+##### Multiple switches with Docker Compose
+
+Run one container per switch, each on its own port:
+
+```yaml
+services:
+  essstat-sw1:
+    image: essstat
+    environment:
+      EXPORTER: "1"
+      ESS_HOST: 192.168.1.10
+      ESS_PASSWORD: secret1
+    ports:
+      - "9101:9101"
+    restart: unless-stopped
+
+  essstat-sw2:
+    image: essstat
+    environment:
+      EXPORTER: "1"
+      ESS_HOST: 192.168.1.11
+      ESS_PASSWORD: secret2
+      ESS_LISTEN: 0.0.0.0:9102
+    ports:
+      - "9102:9102"
+    restart: unless-stopped
+```
+
+Then in `prometheus.yml`:
+
+    scrape_configs:
+      - job_name: tplink_switches
+        static_configs:
+          - targets:
+              - 'localhost:9101'
+              - 'localhost:9102'
 
 ### Zabbix Integration
 
@@ -102,11 +181,11 @@ it. Once it is in place, restart the zabbix-agent2 service so that the file will
 1. Add host  
     - **Configuration** → **Hosts** → **Create host**  
         - Host name: use the switch name or IP (your choice)  
-        - Groups: pick an appropriate host group (e.g., “Network/Switches”)  
+        - Groups: pick an appropriate host group (e.g., "Network/Switches")  
 
 1. Interface (important)  
-    - Add a Zabbix agent interface that points to the Zabbix server’s agent, not the switch:  
-        - DNS/IP: 127.0.0.1 (or the Zabbix server’s IP)  
+    - Add a Zabbix agent interface that points to the Zabbix server's agent, not the switch:  
+        - DNS/IP: 127.0.0.1 (or the Zabbix server's IP)  
         - Port: 10050  
     - Rationale: the server polls its own agent, which runs your script and reaches the switch using the key parameters.  
 
@@ -116,7 +195,7 @@ it. Once it is in place, restart the zabbix-agent2 service so that the file will
 1. Set required host-level macros  
     - **Macros tab** → **Add:**  
         - `{$ESS_IP}` = _switch management IP_ or _FQDN_ 
-          (If you prefer, you can leave `{$SWITCH_IP}` blank and set it to `{HOST.HOST}`, provided the host name is the switch’s resolvable name/IP.)  
+          (If you prefer, you can leave `{$SWITCH_IP}` blank and set it to `{HOST.HOST}`, provided the host name is the switch's resolvable name/IP.)  
         - `{$ESS_PWD}` = •••••• (the real password)  
 
 1. Set optional host-level macros (only if defaults need override)
@@ -131,6 +210,117 @@ it. Once it is in place, restart the zabbix-agent2 service so that the file will
 It may take a few minutes for the LLD to fire and the items and graphs to be created. Multiple switches my be monitored by 
 creating multiple hosts in Zabbix. Just be sure to set the Macros for each host correctly. 
 ![Sample Zabbix chart](./ESS%20Packets%20Zabbix%20Chart.png)
+
+
+### Prometheus Integration
+
+The `-P` / `--prometheus` flag outputs metrics in [Prometheus text exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/),
+suitable for scraping with Prometheus. No additional libraries are required beyond those already used by `essstat.py`.
+
+#### Exported metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `tplink_port_state` | gauge | Port administrative state: `1` = Enabled, `0` = Disabled |
+| `tplink_port_link_speed_mbps` | gauge | Negotiated link speed in Mbps; `0` = link down or autoneg pending |
+| `tplink_port_txgoodpkt_total` | gauge | Cumulative TX good packets (32-bit hardware counter) |
+| `tplink_port_txbadpkt_total` | gauge | Cumulative TX bad/error packets (32-bit hardware counter) |
+| `tplink_port_rxgoodpkt_total` | gauge | Cumulative RX good packets (32-bit hardware counter) |
+| `tplink_port_rxbadpkt_total` | gauge | Cumulative RX bad/error packets (32-bit hardware counter) |
+
+All metrics carry a `host` label set to the switch hostname/IP passed on the command line, and a `port` label with the port number.
+`tplink_port_link_speed_mbps` also carries a `link_status` label with the raw status string (e.g. `"1000M Full"`).
+
+> **Why `gauge` instead of `counter` for packet metrics?**  
+> The switch hardware counters are 32-bit and wrap at 2³² (~4 billion packets). They also reset to zero on switch reboot.
+> Prometheus `counter` type must be strictly monotonic — a wrap or reboot would appear to Prometheus as a massive negative
+> delta and corrupt `rate()` calculations. Using `gauge` with `delta()` or `increase()` in Grafana queries is safer and
+> more accurate for these counters.
+
+#### Example output
+
+    $ essstat.py myswitch -p ChangeMe -P
+    # HELP tplink_port_state Port administrative state (1=Enabled, 0=Disabled)
+    # TYPE tplink_port_state gauge
+    tplink_port_state{host="myswitch",port="1"} 1 1711929600000
+    tplink_port_state{host="myswitch",port="2"} 1 1711929600000
+    ...
+    
+    # HELP tplink_port_link_speed_mbps Negotiated link speed in Mbps (0 = link down / autoneg pending)
+    # TYPE tplink_port_link_speed_mbps gauge
+    tplink_port_link_speed_mbps{host="myswitch",port="1",link_status="Link Down"} 0 1711929600000
+    tplink_port_link_speed_mbps{host="myswitch",port="2",link_status="1000M Full"} 1000 1711929600000
+    ...
+    
+    # HELP tplink_port_txgoodpkt_total Cumulative TX good packets (32-bit hardware counter, resets on reboot)
+    # TYPE tplink_port_txgoodpkt_total gauge
+    tplink_port_txgoodpkt_total{host="myswitch",port="2"} 3568644976 1711929600000
+    ...
+
+#### Option 1: node_exporter textfile collector (simplest)
+
+The easiest way to get metrics into Prometheus is via the
+[textfile collector](https://github.com/prometheus/node_exporter#textfile-collector) included in `node_exporter`.
+Write the output to a `.prom` file in the collector directory and let `node_exporter` serve it on its `/metrics` endpoint.
+
+Create `/etc/cron.d/essstat-prom` with one entry per switch:
+
+    */1 * * * *  root  /usr/local/bin/essstat.py myswitch -p ChangeMe -P \
+                       > /var/lib/node_exporter/textfile_collector/tplink_myswitch.prom.tmp \
+                 && mv /var/lib/node_exporter/textfile_collector/tplink_myswitch.prom.tmp \
+                       /var/lib/node_exporter/textfile_collector/tplink_myswitch.prom
+
+The atomic `tmp` → final rename prevents Prometheus from scraping a partially written file.
+
+Then add a scrape job to `prometheus.yml` if `node_exporter` is not already scraped:
+
+    scrape_configs:
+      - job_name: node
+        static_configs:
+          - targets: ['localhost:9100']
+
+#### Option 2: standalone HTTP exporter
+
+`essstat_exporter.py` wraps `essstat.py` in a minimal HTTP server so Prometheus can scrape it directly via pull,
+without needing `node_exporter` or a cron job.
+
+    $ python3 essstat_exporter.py --host myswitch --password ChangeMe
+    Listening on http://0.0.0.0:9101/metrics  (switch: myswitch)
+
+Add to `prometheus.yml`:
+
+    scrape_configs:
+      - job_name: tplink_switch
+        static_configs:
+          - targets: ['localhost:9101']
+
+Run one exporter instance per switch, using different `--listen` ports:
+
+    $ python3 essstat_exporter.py --host switch-a --password secretA --listen 0.0.0.0:9101
+    $ python3 essstat_exporter.py --host switch-b --password secretB --listen 0.0.0.0:9102
+
+#### Grafana queries
+
+Once data is flowing into Prometheus, some useful PromQL expressions:
+
+```promql
+# TX throughput (packets/sec) per port
+# delta() is correct here because these are gauge metrics (not counters)
+delta(tplink_port_txgoodpkt_total{host="myswitch"}[1m]) / 60
+
+# RX throughput (packets/sec) per port
+delta(tplink_port_rxgoodpkt_total{host="myswitch"}[1m]) / 60
+
+# Ports currently up
+tplink_port_link_speed_mbps{host="myswitch"} > 0
+
+# Any ports with TX errors in the last 5 minutes
+delta(tplink_port_txbadpkt_total{host="myswitch"}[5m]) > 0
+
+# Any ports with RX errors in the last 5 minutes
+delta(tplink_port_rxbadpkt_total{host="myswitch"}[5m]) > 0
+```
+
 
 ### Accumulate Data in CSV
 
@@ -163,7 +353,7 @@ This macro-enabled Excel workbook is a way to read and chart the port statistics
 
 When using the workbook, the name of the switch and the reporting from and to date/times are specified in the parameter table at the top left of the **WebData** tab. Click the `Update From Web` button to fetch the data into the table and dynamically update the plot on the **PPS Chart** tab. If the switch under study has only eight ports, the extra ports will be hidden automatically. 
 
-The name of the switch and the metric plotted appears in the title of the chart. Once the metrics have been loaded into the table, the different metrics may be loaded into the chart by selecting from the choices in the dropdown cell next to the ‘Chart metric` label. Moving between theses metrics for the same switch does *not* require doing another `Update From Web` operation.
+The name of the switch and the metric plotted appears in the title of the chart. Once the metrics have been loaded into the table, the different metrics may be loaded into the chart by selecting from the choices in the dropdown cell next to the 'Chart metric` label. Moving between theses metrics for the same switch does *not* require doing another `Update From Web` operation.
 
 The table on the **LocalPortNames* tab allows you to override the default port names shown in the chart. This table is entirely optional and defining entries for all ports on a given switch is *not* required (it is perfectly fine to define port name overrides for just a couple ports for a given switch). If you have multiple switches, you can add entries for all of them in a single table.
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# docker-entrypoint.sh
+# Supports two modes:
+#
+#   CLI mode (default) — original behaviour, passes all args straight to essstat.py:
+#     docker run --rm essstat myswitch -p ChangeMe
+#     docker run --rm essstat myswitch -p ChangeMe -P   # one-shot prometheus dump
+#
+#   Exporter mode — long-running HTTP /metrics server for Prometheus scraping:
+#     docker run -e EXPORTER=1 -e ESS_HOST=myswitch -e ESS_PASSWORD=secret \
+#                -p 9101:9101 essstat
+#
+#   Exporter env vars:
+#     ESS_HOST      (required) switch IP or hostname
+#     ESS_PASSWORD  (required) switch admin password
+#     ESS_USERNAME  (default: admin)
+#     ESS_LISTEN    (default: 0.0.0.0:9101)
+
+set -e
+
+if [ "${EXPORTER:-0}" = "1" ]; then
+    # Validate required env vars
+    if [ -z "${ESS_HOST}" ]; then
+        echo "ERROR: ESS_HOST is required in exporter mode" >&2
+        exit 1
+    fi
+    if [ -z "${ESS_PASSWORD}" ]; then
+        echo "ERROR: ESS_PASSWORD is required in exporter mode" >&2
+        exit 1
+    fi
+
+    exec python /app/essstat_exporter.py \
+        --host     "${ESS_HOST}" \
+        --password "${ESS_PASSWORD}" \
+        --username "${ESS_USERNAME:-admin}" \
+        --listen   "${ESS_LISTEN:-0.0.0.0:9101}" \
+        --essstat  /app/essstat.py
+else
+    exec python /app/essstat.py "$@"
+fi

--- a/essstat.py
+++ b/essstat.py
@@ -1,30 +1,53 @@
 #!/usr/bin/env python3
 # coding: utf-8
 
-__author__ = "Peter Smode"
+__author__    = "Peter Smode"
 __copyright__ = "Copyright 2020, Peter Smode"
-__credits__ = "Peter Smode"
-__license__ = "GPL 3.0"
-__version__ = "1.0.0"
+__credits__   = "Peter Smode"
+__license__   = "GPL 3.0"
+__version__   = "1.0.0+prometheus"
 __maintainer__ = "Peter Smode"
-__email__ = "psmode@kitsnet.us"
-__status__ = "RC"
+__email__     = "psmode@kitsnet.us"
+__status__    = "RC"
 
-import argparse, pprint, re, requests, sys, json
+# Patch: added -P / --prometheus output mode (Prometheus text exposition format)
+# NOTE: the original -P short flag for --port has been renamed to -n to free up -P.
+
+import argparse, pprint, re, requests, sys, json, time
 from datetime import datetime
 from bs4 import BeautifulSoup
 
-# Numeric mappings
-TPlinkStatus = {'0': 0, '1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6}
-TPstate = {'0': 0, '1': 1}
 
-# String mappings
+# ---------------------------------------------------------------------------
+# Numeric mappings (used for JSON / --1line raw output)
+# ---------------------------------------------------------------------------
+TPlinkStatus = {'0': 0, '1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6}
+TPstate      = {'0': 0, '1': 1}
+
+# String mappings (used for human-readable / Zabbix / Prometheus output)
 TPlinkStatusNames = {
-    '0': "Link Down", '1': "LS 1", '2': "10M Half",
-    '3': "10M Full", '4': "LS 4", '5': "100M Full", '6': "1000M Full"
+    '0': "Link Down", '1': "LS 1",      '2': "10M Half",
+    '3': "10M Full",  '4': "LS 4",      '5': "100M Full", '6': "1000M Full"
 }
 TPstateNames = {'0': 'Disabled', '1': 'Enabled'}
 
+# Speed lookup for Prometheus link-speed gauge (Mbps; 0 = link down)
+_LINK_SPEED_MAP = {
+    "link down":  0,
+    "ls 1":       0,
+    "ls 4":       0,
+    "10m half":   10,
+    "10m full":   10,
+    "100m half":  100,
+    "100m full":  100,
+    "1000m half": 1000,
+    "1000m full": 1000,
+}
+
+
+# ---------------------------------------------------------------------------
+# Notebook detection
+# ---------------------------------------------------------------------------
 def isnotebook():
     try:
         shell = get_ipython().__class__.__name__
@@ -32,31 +55,24 @@ def isnotebook():
     except NameError:
         return False
 
+
+# ---------------------------------------------------------------------------
+# Encode output (text / JSON / Zabbix LLD)
+# ---------------------------------------------------------------------------
 def encode_output(data, mode="text"):
-    """
-    Encode data into text, JSON, or Zabbix LLD.
-    data can be dict (system info) or list of dicts (ports).
-    """
+    """Encode data into text, JSON, or Zabbix LLD format."""
     if mode == "lld":
         lld = {"data": []}
         if isinstance(data, dict):
-            entry = {}
-            for k, v in data.items():
-                macro_name = "{#" + str(k).upper() + "}"
-                entry[macro_name] = v
+            entry = {"{#" + str(k).upper() + "}": v for k, v in data.items()}
             lld["data"].append(entry)
         elif isinstance(data, list):
             for d in data:
-                entry = {}
-                for k, v in d.items():
-                    macro_name = "{#" + str(k).upper() + "}"
-                    entry[macro_name] = v
+                entry = {"{#" + str(k).upper() + "}": v for k, v in d.items()}
                 lld["data"].append(entry)
         return json.dumps(lld, indent=2)
-
     elif mode == "json":
         return json.dumps(data, indent=2)
-
     else:  # text
         if isinstance(data, dict):
             return "\n".join(f"{k}: {v}" for k, v in data.items())
@@ -65,8 +81,10 @@ def encode_output(data, mode="text"):
         else:
             return str(data)
 
-# ---------- Debug helpers (for any GET/POST) ----------
 
+# ---------------------------------------------------------------------------
+# Debug helpers
+# ---------------------------------------------------------------------------
 def _mask(s, keep=4):
     if not isinstance(s, str) or len(s) <= keep:
         return s
@@ -80,70 +98,146 @@ def dump_response(r, label=""):
     print("elapsed:", r.elapsed)
     print("encoding:", r.encoding)
     print("apparent_encoding:", r.apparent_encoding)
-
     masked_cookies = {k: _mask(v) for k, v in r.cookies.get_dict().items()}
     print("cookies:", masked_cookies)
-
     hdrs = dict(r.headers)
     if "Set-Cookie" in hdrs:
         hdrs["Set-Cookie"] = _mask(hdrs["Set-Cookie"])
     print("headers:", hdrs)
-
     print("history:", [h.url for h in r.history])
     print("is_redirect:", r.is_redirect, "is_permanent_redirect:", r.is_permanent_redirect)
     print("links:", r.links)
-
-    # Full response body
     print("text (full):")
     print(r.text)
     print("content length:", len(r.content))
     print("===========================")
 
-# ------------------ MAIN ------------------
 
+# ---------------------------------------------------------------------------
+# Prometheus output
+# ---------------------------------------------------------------------------
+def _prom_block(name, help_text, mtype, rows, ts_suffix):
+    """Emit one Prometheus metric family: HELP + TYPE + all samples."""
+    print(f"# HELP {name} {help_text}")
+    print(f"# TYPE {name} {mtype}")
+    for labels, value in rows:
+        print(f"{name}{{{labels}}} {value}{ts_suffix}")
+    print()
+
+
+def output_prometheus(switch_host, port_data, timestamp_ms=None):
+    """
+    Print Prometheus text exposition format for all port metrics.
+
+    port_data  – list of dicts with keys:
+                   port (int), state (str 'Enabled'/'Disabled'),
+                   link_status (str), TxGoodPkt, TxBadPkt, RxGoodPkt, RxBadPkt (int)
+    timestamp_ms – Unix epoch milliseconds appended to each sample line.
+                   Pass None to omit (Prometheus uses scrape time in pull mode).
+    """
+    ts = f" {timestamp_ms}" if timestamp_ms is not None else ""
+    hl = f'host="{switch_host}"'
+
+    # -- port_state (1 = Enabled, 0 = Disabled) ------------------------------
+    _prom_block(
+        name="tplink_port_state",
+        help_text="Port administrative state (1=Enabled, 0=Disabled)",
+        mtype="gauge",
+        rows=[
+            (f'{hl},port="{p["port"]}"',
+             1 if str(p["state"]).strip().lower() == "enabled" else 0)
+            for p in port_data
+        ],
+        ts_suffix=ts,
+    )
+
+    # -- link speed (Mbps; 0 = link down) ------------------------------------
+    _prom_block(
+        name="tplink_port_link_speed_mbps",
+        help_text="Negotiated link speed in Mbps (0 = link down / autoneg pending)",
+        mtype="gauge",
+        rows=[
+            (f'{hl},port="{p["port"]}",link_status="{p["link_status"]}"',
+             _LINK_SPEED_MAP.get(p["link_status"].strip().lower(), 0))
+            for p in port_data
+        ],
+        ts_suffix=ts,
+    )
+
+    # -- packet counters ------------------------------------------------------
+    # The switch uses 32-bit hardware counters that wrap at 2^32 and reset on
+    # reboot.  Prometheus 'counter' type must be strictly monotonic, so we use
+    # 'gauge' to avoid confusing rate() on a counter-reset event.
+    for field, help_text in (
+        ("TxGoodPkt", "Cumulative TX good packets (32-bit hardware counter, resets on reboot)"),
+        ("TxBadPkt",  "Cumulative TX bad/error packets (32-bit hardware counter, resets on reboot)"),
+        ("RxGoodPkt", "Cumulative RX good packets (32-bit hardware counter, resets on reboot)"),
+        ("RxBadPkt",  "Cumulative RX bad/error packets (32-bit hardware counter, resets on reboot)"),
+    ):
+        _prom_block(
+            name=f"tplink_port_{field.lower()}_total",
+            help_text=help_text,
+            mtype="gauge",
+            rows=[
+                (f'{hl},port="{p["port"]}"', int(p[field]))
+                for p in port_data
+            ],
+            ts_suffix=ts,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
 if not isnotebook():
     parser = argparse.ArgumentParser(description='TP-Link Easy Smart Switch statistics.')
-    parser.add_argument('target', metavar='TPhost', help='IP address or hostname of switch')
+    parser.add_argument('target',       metavar='TPhost', help='IP address or hostname of switch')
     parser.add_argument('-1', '--1line', action='store_true', help='output on a single line (CSV)')
     parser.add_argument('-d', '--debug', action='store_true', help='activate debugging output')
-    parser.add_argument('-i', '--info', action='store_true', help='fetch system info instead of port statistics')
-    parser.add_argument('-j', '--json', action='store_true', help='output as JSON')
-    parser.add_argument('-l', '--lld', action='store_true', help='output in Zabbix LLD JSON format')
+    parser.add_argument('-i', '--info',  action='store_true', help='fetch system info instead of port statistics')
+    parser.add_argument('-j', '--json',  action='store_true', help='output as JSON')
+    parser.add_argument('-l', '--lld',   action='store_true', help='output in Zabbix LLD JSON format')
     parser.add_argument('-p', '--password', metavar='TPpswd', required=True, help='password for switch access')
     parser.add_argument('-u', '--username', metavar='TPuser', required=False, default='admin', help='username for switch access')
     parser.add_argument('-s', '--statsonly', action='store_true', help='output per-port statistics only (one line per port)')
-    parser.add_argument('-P', '--port', type=int, help='specific port number to retrieve')
+    # NOTE: original short flag was -P; renamed to -n to free -P for --prometheus
+    parser.add_argument('-n', '--port',   type=int, help='specific port number to retrieve')
     parser.add_argument('-M', '--metric', help='metric name for specific port (state, link_status, TxGoodPkt, TxBadPkt, RxGoodPkt, RxBadPkt)')
+    parser.add_argument('-P', '--prometheus', action='store_true',
+                        help='output in Prometheus text exposition format (for /metrics scraping)')
     parser.add_argument('-v', '--Version', action='version',
                         version=f"%(prog)s {__version__}",
                         help="show program's version number and exit")
+
     args = vars(parser.parse_args())
 
-    TPLuser = args['username']
-    TPLpswd = args['password']
-    BASE_URL = "http://" + args['target']
-    TPLdebug = args['debug']
-    TPLlld = args['lld']
-    PORT = args['port']
-    METRIC = args['metric']
-    TPLone = args['1line']
+    TPLuser      = args['username']
+    TPLpswd      = args['password']
+    BASE_URL     = "http://" + args['target']
+    TPLdebug     = args['debug']
+    TPLlld       = args['lld']
+    PORT         = args['port']
+    METRIC       = args['metric']
+    TPLone       = args['1line']
     TPLstatsonly = args['statsonly']
-    TPLjson = args['json']
-    TPLinfo = args['info']
+    TPLjson      = args['json']
+    TPLinfo      = args['info']
+    TPLprometheus = args['prometheus']
 
 else:
     # Notebook defaults
-    TPLuser = 'admin'
-    TPLpswd = 'changeme'
-    BASE_URL = "http://tpl-host"
-    TPLdebug = True
-    TPLlld = False
-    PORT = None
-    METRIC = None
-    TPLone = False
-    TPLstatsonly = False
-    TPLjson = False
-    TPLinfo = False
+    TPLuser       = 'admin'
+    TPLpswd       = 'changeme'
+    BASE_URL      = "http://tpl-host"
+    TPLdebug      = True
+    TPLlld        = False
+    PORT          = None
+    METRIC        = None
+    TPLone        = False
+    TPLstatsonly  = False
+    TPLjson       = False
+    TPLinfo       = False
+    TPLprometheus = False
 
 if TPLdebug:
     print(TPLuser, TPLpswd, BASE_URL)
@@ -151,7 +245,7 @@ if TPLdebug:
 # Create requests session
 s = requests.Session()
 
-# Wrap s.get/s.post so any request will dump when -d is on
+# Wrap s.get/s.post to dump when -d is on
 _orig_get, _orig_post = s.get, s.post
 
 def debug_get(*args, **kwargs):
@@ -166,53 +260,51 @@ def debug_post(*args, **kwargs):
         dump_response(resp, "POST")
     return resp
 
-s.get = debug_get
+s.get  = debug_get
 s.post = debug_post
 
 # Login
-data = {"logon": "Login", "username": TPLuser, "password": TPLpswd}
+data    = {"logon": "Login", "username": TPLuser, "password": TPLpswd}
 headers = {'Referer': f'{BASE_URL}/Logout.htm'}
 try:
     r = s.post(f'{BASE_URL}/logon.cgi', data=data, headers=headers, timeout=5)
 except requests.exceptions.Timeout:
     sys.exit("ERROR: Timeout Error at login")
 except requests.exceptions.RequestException as err:
-    sys.exit("ERROR: General error at login: "+str(err))
+    sys.exit("ERROR: General error at login: " + str(err))
 
-# ------------------ SYSTEM INFO (from <script> var info_ds) ------------------
-# ------------------ SYSTEM INFO (from <script> var info_ds) ------------------
+
+# ---------------------------------------------------------------------------
+# SYSTEM INFO
+# ---------------------------------------------------------------------------
 if TPLinfo:
     r = s.get(f'{BASE_URL}/SystemInfoRpm.htm', headers={'Referer': BASE_URL}, timeout=6)
     if str(r) != "<Response [200]>":
         sys.exit("ERROR: Could not retrieve SystemInfoRpm.htm")
 
     soup = BeautifulSoup(r.text, 'html.parser')
-
-    # Find the <script> that defines info_ds
     script_text = ""
     for sc in soup.find_all("script"):
         txt = sc.string if sc.string is not None else sc.text
         if txt and "var info_ds" in txt:
             script_text = txt
             break
+
     if not script_text:
         sys.exit("ERROR: Could not find info_ds in SystemInfoRpm.htm")
 
-    # Helper: extract first string inside array for a given key
-    def extract_first(name: str) -> str:
-        # Matches: name:[ "value" ]  (with arbitrary whitespace/newlines)
+    def extract_first(name):
         m = re.search(rf'{name}\s*:\s*\[\s*"([^"]*)"\s*\]', script_text, re.DOTALL)
         return m.group(1) if m else ""
 
-    # Build sysinfo with the device's original keys, unwrapped to strings
     sysinfo = {
-        "descriStr":   extract_first("descriStr"),
-        "macStr":      extract_first("macStr"),
-        "ipStr":       extract_first("ipStr"),
-        "netmaskStr":  extract_first("netmaskStr"),
-        "gatewayStr":  extract_first("gatewayStr"),
-        "firmwareStr": extract_first("firmwareStr"),
-        "hardwareStr": extract_first("hardwareStr"),
+        "descriStr":  extract_first("descriStr"),
+        "macStr":     extract_first("macStr"),
+        "ipStr":      extract_first("ipStr"),
+        "netmaskStr": extract_first("netmaskStr"),
+        "gatewayStr": extract_first("gatewayStr"),
+        "firmwareStr":extract_first("firmwareStr"),
+        "hardwareStr":extract_first("hardwareStr"),
     }
 
     if TPLlld:
@@ -225,18 +317,18 @@ if TPLinfo:
         print(f"{current_dt}," + ",".join(oneline))
     else:
         print(encode_output(sysinfo, mode="text"))
-
     sys.exit(0)
 
-# ------------------ PORT STATISTICS ------------------
 
+# ---------------------------------------------------------------------------
+# PORT STATISTICS
+# ---------------------------------------------------------------------------
 headers = {
     'Referer': f'{BASE_URL}/',
     'Accept': "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
     'Upgrade-Insecure-Requests': "1"
 }
 r = s.get(f'{BASE_URL}/PortStatisticsRpm.htm', headers=headers, timeout=6)
-
 if str(r) != "<Response [200]>":
     sys.exit("ERROR: Login failure - bad credential?")
 
@@ -263,28 +355,46 @@ e5 = re.split(",", edict['pkts'])
 
 # Build per-port dict
 pdict = {}
-for x in range(1, max_port_num+1):
+for x in range(1, max_port_num + 1):
     pdict[x] = {
-        'state': TPstate[e3[x-1]],
-        'link_status': TPlinkStatus[e4[x-1]],
-        'TxGoodPkt': int(e5[((x-1)*4)]),
-        'TxBadPkt': int(e5[((x-1)*4)+1]),
-        'RxGoodPkt': int(e5[((x-1)*4)+2]),
-        'RxBadPkt': int(e5[((x-1)*4)+3])
+        'state':      TPstate[e3[x-1]],
+        'link_status':TPlinkStatus[e4[x-1]],
+        'TxGoodPkt':  int(e5[((x-1)*4)]),
+        'TxBadPkt':   int(e5[((x-1)*4)+1]),
+        'RxGoodPkt':  int(e5[((x-1)*4)+2]),
+        'RxBadPkt':   int(e5[((x-1)*4)+3])
     }
 
+# ---------------------------------------------------------------------------
 # Output modes
-if TPLlld:
+# ---------------------------------------------------------------------------
+
+if TPLprometheus:
+    # Build a list of port dicts with string names (not numeric codes)
+    prom_list = []
+    for x in range(1, max_port_num + 1):
+        prom_list.append({
+            "port":        x,
+            "state":       TPstateNames[e3[x-1]],
+            "link_status": TPlinkStatusNames[e4[x-1]],
+            "TxGoodPkt":   pdict[x]['TxGoodPkt'],
+            "TxBadPkt":    pdict[x]['TxBadPkt'],
+            "RxGoodPkt":   pdict[x]['RxGoodPkt'],
+            "RxBadPkt":    pdict[x]['RxBadPkt'],
+        })
+    output_prometheus(args['target'], prom_list, int(time.time() * 1000))
+
+elif TPLlld:
     jlist = []
-    for x in range(1, max_port_num+1):
+    for x in range(1, max_port_num + 1):
         jlist.append({
-            "port": str(x),
-            "state": pdict[x]['state'],
-            "link_status": pdict[x]['link_status'],
-            "TxGoodPkt": pdict[x]['TxGoodPkt'],
-            "TxBadPkt": pdict[x]['TxBadPkt'],
-            "RxGoodPkt": pdict[x]['RxGoodPkt'],
-            "RxBadPkt": pdict[x]['RxBadPkt']
+            "port":       str(x),
+            "state":      pdict[x]['state'],
+            "link_status":pdict[x]['link_status'],
+            "TxGoodPkt":  pdict[x]['TxGoodPkt'],
+            "TxBadPkt":   pdict[x]['TxBadPkt'],
+            "RxGoodPkt":  pdict[x]['RxGoodPkt'],
+            "RxBadPkt":   pdict[x]['RxBadPkt'],
         })
     print(encode_output(jlist, mode="lld"))
 
@@ -297,23 +407,24 @@ elif PORT and METRIC:
 
 elif TPLjson:
     jlist = []
-    for x in range(1, max_port_num+1):
+    for x in range(1, max_port_num + 1):
         jlist.append({
-            "port": x,
-            "state": int(e3[x-1]),
+            "port":        x,
+            "state":       int(e3[x-1]),
             "link_status": int(e4[x-1]),
-            "TxGoodPkt": pdict[x]['TxGoodPkt'],
-            "TxBadPkt": pdict[x]['TxBadPkt'],
-            "RxGoodPkt": pdict[x]['RxGoodPkt'],
-            "RxBadPkt": pdict[x]['RxBadPkt']
+            "TxGoodPkt":   pdict[x]['TxGoodPkt'],
+            "TxBadPkt":    pdict[x]['TxBadPkt'],
+            "RxGoodPkt":   pdict[x]['RxGoodPkt'],
+            "RxBadPkt":    pdict[x]['RxBadPkt'],
         })
     print(encode_output(jlist, mode="json"))
 
 else:
     current_dt = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
     if TPLone:
         print(f"{current_dt},{max_port_num},", end="")
-        for x in range(1, max_port_num+1):
+        for x in range(1, max_port_num + 1):
             end_char = "\n" if x == max_port_num else ","
             print("{0:d},{1:s},{2:s},{3:s},{4:s},{5:s},{6:s}".format(
                 x, e3[x-1], e4[x-1],
@@ -322,8 +433,9 @@ else:
                 e5[((x-1)*4)+2],
                 e5[((x-1)*4)+3]
             ), end=end_char)
+
     elif TPLstatsonly:
-        for x in range(1, max_port_num+1):
+        for x in range(1, max_port_num + 1):
             print("{0:d};{1:s};{2:s};{3:d},{4:d},{5:d},{6:d}".format(
                 x,
                 TPstateNames[e3[x-1]],
@@ -333,8 +445,19 @@ else:
                 pdict[x]['RxGoodPkt'],
                 pdict[x]['RxBadPkt']
             ))
+
     else:
         print(current_dt)
         print(f"max_port_num={max_port_num}")
         if TPLdebug:
             pprint.pprint(pdict)
+        for x in range(1, max_port_num + 1):
+            print("{0:d};{1:s};{2:s};{3:d},{4:d},{5:d},{6:d}".format(
+                x,
+                TPstateNames[e3[x-1]],
+                TPlinkStatusNames[e4[x-1]],
+                pdict[x]['TxGoodPkt'],
+                pdict[x]['TxBadPkt'],
+                pdict[x]['RxGoodPkt'],
+                pdict[x]['RxBadPkt']
+            ))

--- a/essstat_exporter.py
+++ b/essstat_exporter.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+essstat_exporter.py  –  Minimal Prometheus HTTP exporter for essstat
+─────────────────────────────────────────────────────────────────────
+Wraps essstat.py in an HTTP server so Prometheus can scrape /metrics directly.
+Listens on 0.0.0.0:9101 by default.
+
+Usage:
+    ./essstat_exporter.py --host 192.168.1.1 --password secret
+    ./essstat_exporter.py --host 192.168.1.1 --password secret --listen 0.0.0.0:9101
+
+Then add to prometheus.yml:
+    scrape_configs:
+      - job_name: tplink_switch
+        static_configs:
+          - targets: ['localhost:9101']
+
+For multiple switches, run one instance per switch on different ports:
+    ./essstat_exporter.py --host switch-a --password secretA --listen 0.0.0.0:9101
+    ./essstat_exporter.py --host switch-b --password secretB --listen 0.0.0.0:9102
+"""
+
+import argparse
+import subprocess
+import sys
+import os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+# ── scrape helper ─────────────────────────────────────────────────────────────
+
+def scrape(essstat_path: str, host: str, password: str, username: str):
+    """
+    Invoke essstat.py -P and return (http_status, body_text).
+    Returns 200 + Prometheus text on success, 500 + error message on failure.
+    """
+    cmd = [
+        sys.executable, essstat_path,
+        '-P',
+        '-p', password,
+        '-u', username,
+        host,
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            err = result.stderr.strip() or result.stdout.strip() or 'essstat exited non-zero'
+            return 500, f'# essstat error (exit {result.returncode}): {err}\n'
+        return 200, result.stdout
+    except subprocess.TimeoutExpired:
+        return 500, '# essstat error: scrape timed out after 15s\n'
+    except Exception as exc:
+        return 500, f'# essstat error: {exc}\n'
+
+
+# ── HTTP handler ──────────────────────────────────────────────────────────────
+
+class MetricsHandler(BaseHTTPRequestHandler):
+    essstat_path = './essstat.py'
+    switch_host  = None
+    password     = None
+    username     = 'admin'
+
+    def do_GET(self):
+        if self.path not in ('/metrics', '/metrics/'):
+            self.send_response(404)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            self.wfile.write(b'404 Not Found - use /metrics\n')
+            return
+
+        status, body = scrape(
+            self.essstat_path,
+            self.switch_host,
+            self.password,
+            self.username,
+        )
+        self.send_response(status)
+        self.send_header('Content-Type', 'text/plain; version=0.0.4; charset=utf-8')
+        self.end_headers()
+        self.wfile.write(body.encode('utf-8'))
+
+    def log_message(self, fmt, *args):
+        print(f'[scrape] {self.address_string()} -> {args[1]}', flush=True)
+
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    # Resolve the default essstat.py path relative to this script's directory
+    script_dir   = os.path.dirname(os.path.realpath(__file__))
+    default_path = os.path.join(script_dir, 'essstat.py')
+
+    ap = argparse.ArgumentParser(
+        description='Prometheus HTTP exporter for TP-Link Easy Smart Switch via essstat.py'
+    )
+    ap.add_argument('--host',     required=True,
+                    help='Switch IP or hostname')
+    ap.add_argument('--password', required=True,
+                    help='Switch admin password')
+    ap.add_argument('--username', default='admin',
+                    help='Switch admin username (default: admin)')
+    ap.add_argument('--listen',   default='0.0.0.0:9101',
+                    help='Listen on this address:port (default: 0.0.0.0:9101)')
+    ap.add_argument('--essstat',  default=default_path,
+                    help=f'Path to essstat.py (default: {default_path})')
+    args = ap.parse_args()
+
+    # Validate essstat.py exists before binding the socket
+    if not os.path.isfile(args.essstat):
+        ap.error(f'essstat.py not found at: {args.essstat}  (use --essstat to specify path)')
+
+    addr, port_str = args.listen.rsplit(':', 1)
+    try:
+        port = int(port_str)
+    except ValueError:
+        ap.error(f'Invalid listen port: {port_str!r}')
+
+    MetricsHandler.essstat_path = args.essstat
+    MetricsHandler.switch_host  = args.host
+    MetricsHandler.password     = args.password
+    MetricsHandler.username     = args.username
+
+    print(f'essstat_exporter listening on http://{addr}:{port}/metrics')
+    print(f'  switch  : {args.host}')
+    print(f'  essstat : {args.essstat}')
+
+    try:
+        HTTPServer((addr, port), MetricsHandler).serve_forever()
+    except KeyboardInterrupt:
+        print('\nStopped.')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Added support for Prometheus scraping both in one-shot mode (direct output in Prometheus `/metrics` format) and in server mode, where the python code and/or its Docker-ized version listen on a TCP port and provide a `/metrics` endpoint that Prometheus can scrape.